### PR TITLE
using javascript ternary operator to prevent click event on (first, previous, next, last) page

### DIFF
--- a/src/JwPagination.vue
+++ b/src/JwPagination.vue
@@ -1,19 +1,22 @@
+
+
+
 <template>
     <ul v-if="pager.pages && pager.pages.length" class="pagination" :style="ulStyles">
         <li class="page-item first" :class="{'disabled': pager.currentPage === 1}" :style="liStyles">
-            <a class="page-link" @click="setPage(1)" :style="aStyles">{{labels.first}}</a>
+            <a class="page-link" v-on="pager.currentPage === 1 ? { click:() => {}} : {click:() => {setPage(1)} }" :style="aStyles">{{labels.first}}</a>
         </li>
         <li class="page-item previous" :class="{'disabled': pager.currentPage === 1}" :style="liStyles">
-            <a class="page-link" @click="setPage(pager.currentPage - 1)" :style="aStyles">{{labels.previous}}</a>
+            <a class="page-link" v-on="pager.currentPage === 1 ? {click:() => {}} : {click:() => {setPage(pager.currentPage - 1)}}" :style="aStyles">{{labels.previous}}</a>
         </li>
         <li v-for="page in pager.pages" :key="page" class="page-item page-number" :class="{'active': pager.currentPage === page}" :style="liStyles">
             <a class="page-link" @click="setPage(page)" :style="aStyles">{{page}}</a>
         </li>
         <li class="page-item next" :class="{'disabled': pager.currentPage === pager.totalPages}" :style="liStyles">
-            <a class="page-link" @click="setPage(pager.currentPage + 1)" :style="aStyles">{{labels.next}}</a>
+            <a class="page-link" v-on="pager.currentPage === pager.totalPages ? { click:() => {}} : {click:() => {setPage(pager.currentPage + 1)} }" :style="aStyles">{{labels.next}}</a>
         </li>
         <li class="page-item last" :class="{'disabled': pager.currentPage === pager.totalPages}" :style="liStyles">
-            <a class="page-link" @click="setPage(pager.totalPages)" :style="aStyles">{{labels.last}}</a>
+            <a class="page-link" v-on="pager.currentPage === pager.totalPages ? {click:() => {}} : {click:() => {setPage(pager.totalPages)}}" :style="aStyles">{{labels.last}}</a>
         </li>
     </ul>
 </template>


### PR DESCRIPTION
Hi, first of all i love your work! thanks for your efforts!

I want to suggest one thing to commit which is about prevent click events.
I thought clicking first page and previous page should be prevented when i am at the first page.
Also next page and the last page shouldn't be clicked when i'm at the last page.

The class ternary operator already applied, such as `:class="{'disabled': pager.currentPage === 1}"`
But i can't see any javascript ternary operator to prevent the events.
So i added the javascript ternary operator code to support your code 😜
Check it out. Thank you!